### PR TITLE
Обработка исключений при получении ip-адреса

### DIFF
--- a/src/BuildingBlocks.SystemInfo/Providers/AppDiagnosticInfoProvider.cs
+++ b/src/BuildingBlocks.SystemInfo/Providers/AppDiagnosticInfoProvider.cs
@@ -105,11 +105,18 @@ namespace BuildingBlocks.SystemInfo.Providers
 
         public string GetIpAddress()
         {
-            var hostEntry = Dns.GetHostEntry(Dns.GetHostName());
-            var ipAddress = (from addr in hostEntry.AddressList
-                             where addr.AddressFamily == AddressFamily.InterNetwork
-                             select addr.ToString()).FirstOrDefault();
-            return ipAddress;
+            try
+            {
+                var hostEntry = Dns.GetHostEntry(Dns.GetHostName());
+                var ipAddress = (from addr in hostEntry.AddressList
+                                 where addr.AddressFamily == AddressFamily.InterNetwork
+                                 select addr.ToString()).FirstOrDefault();
+                return ipAddress;
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
+            }
         }
 
         public SoftwareInfo GetSoftwareInfo()


### PR DESCRIPTION
Dns.GetHostEntry(Dns.GetHostName()); - Не всегда может распознать ip-адрес (например, если hostname равен "1")
